### PR TITLE
Add support for additional capabilities for CosmosDB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Setting `all` in logs and metrics will send all possible diagnostics to destinat
 
 The variable `capabilities` can be used to enable following capabilities (comma separated): 
 
-AllowSelfServeUpgradeToMongo36, DisableRateLimitingResponses, EnableAggregationPipeline, EnableCassandra, EnableGremlin, EnableMongo, EnableTable, EnableServerless, MongoDBv3.4 and mongoEnableDocLevelTTL.
+AllowSelfServeUpgradeToMongo36, DisableRateLimitingResponses, EnableAggregationPipeline, EnableCassandra, EnableGremlin, EnableTable, EnableServerless, MongoDBv3.4 and mongoEnableDocLevelTTL.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ module "cosmosdb" {
 Diagnostics settings can be sent to either storage account, event hub or Log Analytics workspace. The variable `diagnostics.destination` is the id of receiver, ie. storage account id, event namespace authorization rule id or log analytics resource id. Depending on what id is it will detect where to send. Unless using event namespace the `eventhub_name` is not required, just set to `null` for storage account and log analytics workspace.
 
 Setting `all` in logs and metrics will send all possible diagnostics to destination. If not using `all` type name of categories to send.
+
+## Capabilities
+
+The variable `capabilities` can be used to enable following capabilities (comma separated): 
+
+AllowSelfServeUpgradeToMongo36, DisableRateLimitingResponses, EnableAggregationPipeline, EnableCassandra, EnableGremlin, EnableMongo, EnableTable, EnableServerless, MongoDBv3.4 and mongoEnableDocLevelTTL.

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -4,6 +4,7 @@ module "cosmosdb" {
   name                = "cosmosdb"
   resource_group_name = "cosmosdb-rg"
   location            = "westeurope"
+  capabilities        = ["DisableRateLimitingResponses"]
 
   ip_range_filter = "10.221.100.10,10.221.101.0/24"
 

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,14 @@ resource "azurerm_cosmosdb_account" "main" {
   ip_range_filter           = var.ip_range_filter
 
   capabilities {
-    name = var.capabilities
+    name = "EnableMongo"
+  }
+
+  dynamic "capabilities" {
+    for_each = var.capabilities != null ? var.capabilities : []
+    content {
+      name = capabilities.value
+    }
   }
 
   consistency_policy {

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_cosmosdb_account" "main" {
   ip_range_filter           = var.ip_range_filter
 
   capabilities {
-    name = "EnableMongo"
+    name = var.capabilities
   }
 
   consistency_policy {

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,9 @@ variable "ip_range_filter" {
   type        = string
   default     = null
 }
+
+variable "capabilities" {
+  description = "Configures the capabilities to enable for this Cosmos DB account. Check README.md for valid values."
+  type        = list(string)
+  default     = ["EnableMongo"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,5 +49,5 @@ variable "ip_range_filter" {
 variable "capabilities" {
   description = "Configures the capabilities to enable for this Cosmos DB account. Check README.md for valid values."
   type        = list(string)
-  default     = ["EnableMongo"]
+  default     = null
 }


### PR DESCRIPTION
In Azure CosmosDB GUI there is a possibility to turn on Server Side Retry (SSR) to prevent error 429 (troughput limit RU/s). I have found out that this can be set also in Terraform module. This PR will support for adding multiple flags for CosmosDB account
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account#name