### PR TITLE
Add support for ignoring indexes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,11 @@ resource "azurerm_cosmosdb_mongo_collection" main {
   database_name       = each.value.database
   shard_key           = each.value.shard_key
   throughput          = each.value.throughput
+
+  lifecycle {
+    ignore_changes = [index]
+  }
+
 }
 
 resource "azurerm_monitor_diagnostic_setting" "cosmosdb" {


### PR DESCRIPTION
Background: Terraform overrides existing indexes that were created by application in a collection that is managed by Terraform