### PR TITLE
Change ip_range_filter variable type

### DIFF
--- a/examples/diagnostics/main.tf
+++ b/examples/diagnostics/main.tf
@@ -5,7 +5,7 @@ module "cosmosdb" {
   resource_group_name = "cosmosdb-rg"
   location            = "westeurope"
 
-  ip_range_filter = "10.221.100.10,10.221.101.0/24"
+  ip_range_to_filter =  ["10.221.100.10","10.221.101.0/24"]
 
   databases = {
     mydb1 = {

--- a/examples/diagnostics/main.tf
+++ b/examples/diagnostics/main.tf
@@ -5,7 +5,7 @@ module "cosmosdb" {
   resource_group_name = "cosmosdb-rg"
   location            = "westeurope"
 
-  ip_range_to_filter =  ["10.221.100.10","10.221.101.0/24"]
+  ip_range_filter =  ["10.221.100.10","10.221.101.0/24"]
 
   databases = {
     mydb1 = {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -6,7 +6,7 @@ module "cosmosdb" {
   location            = "westeurope"
   capabilities        = ["DisableRateLimitingResponses"]
 
-  ip_range_filter = "10.221.100.10,10.221.101.0/24"
+  ip_range_to_filter = ["10.221.100.10","10.221.101.0/24"]
 
   databases = {
     mydb1 = {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -6,7 +6,7 @@ module "cosmosdb" {
   location            = "westeurope"
   capabilities        = ["DisableRateLimitingResponses"]
 
-  ip_range_to_filter = ["10.221.100.10","10.221.101.0/24"]
+  ip_range_filter = ["10.221.100.10","10.221.101.0/24"]
 
   databases = {
     mydb1 = {

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "azurerm_cosmosdb_account" "main" {
   kind                = "MongoDB"
 
   enable_automatic_failover = false
-  ip_range_filter           = join(",", var.ip_range_to_filter)
+  ip_range_filter           = join(",", var.ip_range_filter)
 
   capabilities {
     name = "EnableMongo"

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "azurerm_cosmosdb_account" "main" {
   kind                = "MongoDB"
 
   enable_automatic_failover = false
-  ip_range_filter           = var.ip_range_filter
+  ip_range_filter           = join(",", var.ip_range_to_filter)
 
   capabilities {
     name = "EnableMongo"

--- a/variables.tf
+++ b/variables.tf
@@ -40,10 +40,10 @@ variable "diagnostics" {
   default = null
 }
 
-variable "ip_range_filter" {
+variable "ip_range_to_filter" {
   description = "CosmosDB Firewall Support: This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IP's for a given database account. IP addresses/ranges must be comma separated and must not contain any spaces"
-  type        = string
-  default     = null
+  type        = list(string)
+  default     = []
 }
 
 variable "capabilities" {

--- a/variables.tf
+++ b/variables.tf
@@ -40,8 +40,8 @@ variable "diagnostics" {
   default = null
 }
 
-variable "ip_range_to_filter" {
-  description = "CosmosDB Firewall Support: This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IP's for a given database account. IP addresses/ranges must be comma separated and must not contain any spaces"
+variable "ip_range_filter" {
+  description = "CosmosDB Firewall Support: This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IP's for a given database account. IP addresses/ranges must be a comma separated list of strings"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
In order to add AKS IP  [dependency.hub.outputs.public_ip_prefix] to ip_range_filter variable this has to be changed from string to list(string)