### PR TITLE
Add support for multiple regions

### DIFF
--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -1,0 +1,41 @@
+module "cosmosdb" {
+  source = "../../"
+
+  name                      = "cosmosdb"
+  resource_group_name       = "cosmosdb-rg"
+  location                  = "westeurope"
+  capabilities              = ["DisableRateLimitingResponses"]
+  enable_automatic_failover = true
+
+  ip_range_filter = ["10.221.100.10", "10.221.101.0/24"]
+
+  databases = {
+    mydb1 = {
+      throughput = 400
+      collections = [
+        { name = "col0", shard_key = "somekey_0", throughput = 1000 },
+        { name = "col1", shard_key = "somekey_1" }
+      ]
+    }
+    mydb2 = {
+      max_throughput = 4000
+      collections    = [{ name = "mycol2", shard_key = "someother_key" }]
+    }
+    mydb3 = {
+      collections = [{ name = "mycol3", shard_key = "mycol3_key", max_throughput = 5000 }]
+    }
+  }
+
+  additional_geo_locations = {
+    norwayeast = {
+      location          = "norwayeast"
+      failover_priority = 1 # must be > 0
+      zone_redundant    = false # optional parameter
+    }
+  }
+
+  tags = {
+    tag1 = "value1"
+  }
+
+}

--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -5,7 +5,7 @@ module "cosmosdb" {
   resource_group_name       = "cosmosdb-rg"
   location                  = "westeurope"
   capabilities              = ["DisableRateLimitingResponses"]
-  enable_automatic_failover = true
+  enable_automatic_failover = true # false by default
 
   ip_range_filter = ["10.221.100.10", "10.221.101.0/24"]
 

--- a/main.tf
+++ b/main.tf
@@ -76,16 +76,12 @@ resource "azurerm_cosmosdb_account" "main" {
     max_staleness_prefix    = 100
   }
 
-  geo_location {
-    location          = azurerm_resource_group.main.location
-    failover_priority = 0
-  }
-
   dynamic "geo_location" {
-    for_each = var.additional_regions
+    for_each = var.locations
     content {
       location          = geo_location.value.location
       failover_priority = geo_location.value.failover_priority
+      zone_redundant    = geo_location.value.zone_redundant
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,14 @@ resource "azurerm_cosmosdb_account" "main" {
     failover_priority = 0
   }
 
+  dynamic "geo_location" {
+    for_each = var.additional_regions
+    content {
+      location          = geo_location.value.location
+      failover_priority = geo_location.value.failover_priority
+    }
+  }
+
   dynamic "virtual_network_rule" {
     for_each = var.virtual_network_rules
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "azurerm_cosmosdb_account" "main" {
   resource_group_name               = azurerm_resource_group.main.name
   offer_type                        = "Standard"
   kind                              = "MongoDB"
-  enable_automatic_failover         = false
+  enable_automatic_failover         = var.enable_automatic_failover
   ip_range_filter                   = join(",", var.ip_range_filter)
   is_virtual_network_filter_enabled = length(var.virtual_network_rules) > 0
   tags                              = var.tags
@@ -76,8 +76,13 @@ resource "azurerm_cosmosdb_account" "main" {
     max_staleness_prefix    = 100
   }
 
+  geo_location {
+    location          = azurerm_resource_group.main.location
+    failover_priority = 0
+  }
+
   dynamic "geo_location" {
-    for_each = var.locations
+    for_each = var.additional_geo_locations
     content {
       location          = geo_location.value.location
       failover_priority = geo_location.value.failover_priority

--- a/test/example_ut_test.go
+++ b/test/example_ut_test.go
@@ -13,6 +13,7 @@ func TestUT_Examples(t *testing.T) {
 		"../examples/simple",
 		"../examples/diagnostics",
 		"../examples/network-rules",
+		"../examples/multi-region",
 	}
 
 	for _, test := range tests {

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,15 @@ variable "databases" {
   default = {}
 }
 
+variable "additional_regions" {
+  description = "List of additional regions for multi-region replication"
+  type = map(object({
+    location          = string
+    failover_priority = number
+  }))
+  default = {}
+}
+
 variable "diagnostics" {
   description = "Diagnostic settings for those resources that support it. See README.md for details on configuration."
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "location" {
   description = "The Azure Region in which to create resource."
 }
 
+variable "enable_automatic_failover" {
+  description = "Enable automatic failover for this Cosmos DB account."
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Tags to apply to all resources created."
   type        = map(string)
@@ -31,7 +37,7 @@ variable "databases" {
   default = {}
 }
 
-variable "locations" {
+variable "additional_geo_locations" {
   description = "List of locations the geographic locations the data is replicated to."
   type = map(object({
     location          = string

--- a/variables.tf
+++ b/variables.tf
@@ -31,11 +31,12 @@ variable "databases" {
   default = {}
 }
 
-variable "additional_regions" {
-  description = "List of additional regions for multi-region replication"
+variable "locations" {
+  description = "List of locations the geographic locations the data is replicated to."
   type = map(object({
     location          = string
     failover_priority = number
+    zone_redundant    = optional(bool)
   }))
   default = {}
 }


### PR DESCRIPTION
Add support to define secondary locations where data should be replicated. Variable `failover_priority` must be greater than 0. The PR also implements the option to enable automatic failover between the locations by using the `enable_automatic_failover` variable.  

The PR is backward compatible!

Additional secondary regions and automatic failover can be implemented using tau input as

```terraform
inputs {
  enable_automatic_failover = true
  additional_geo_locations = {
    norwayeast = {
      location          = "norwayeast"
      failover_priority = 1
      zone_redundant    = false
    }
  }
}
```