### PR TITLE
add support for specifying mongo server version

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,10 +1,11 @@
 module "cosmosdb" {
   source = "../../"
 
-  name                = "cosmosdb"
-  resource_group_name = "cosmosdb-rg"
-  location            = "westeurope"
-  capabilities        = ["DisableRateLimitingResponses"]
+  name                 = "cosmosdb"
+  resource_group_name  = "cosmosdb-rg"
+  location             = "westeurope"
+  capabilities         = ["DisableRateLimitingResponses"]
+  mongo_server_version = "4.2"
 
   ip_range_filter = ["10.221.100.10", "10.221.101.0/24"]
 

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ resource "azurerm_cosmosdb_account" "main" {
   ip_range_filter                   = join(",", var.ip_range_filter)
   is_virtual_network_filter_enabled = length(var.virtual_network_rules) > 0
   tags                              = var.tags
+  mongo_server_version              = var.mongo_server_version
 
   capabilities {
     name = "EnableMongo"

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,12 @@ variable "name" {
   description = "Name of the CosmosDB Account."
 }
 
+variable "mongo_server_version" {
+  description = "The Server Version of a MongoDB account."
+  type        = string
+  default     = null
+}
+
 variable "resource_group_name" {
   description = "Name of resource group to deploy resources in."
 }


### PR DESCRIPTION
Adds support for specifying mongo server version.

Defaults to null as `mongo_server_version` is an optional parameter.

Tests pass.

Should be backwards compatible.

Example:

```terraform
module "cosmosdb" {

  source = "github.com/avinor/terraform-azurerm-cosmosdb-mongodb?ref=v3.2.1"

  name                 = "cosmosdb"
  resource_group_name  = "cosmosdb-rg"
  location             = "westeurope"
  capabilities         = ["DisableRateLimitingResponses"]
  mongo_server_version = "4.2"

  databases = {
    mydb = {
      throughput  = 400
      collections = [
        { name = "col0", shard_key = "somekey_0", throughput = 1000 },
        { name = "col1", shard_key = "somekey_1" },
      ]
    }
    mydb2 = {
      max_throughput = 5000
      collections    = [{ name = "col2", shard_key = "someotherkey" }]
    }
  }
}
```